### PR TITLE
fix wrong profile addressing in hidGetProfile

### DIFF
--- a/src/meusbd.c
+++ b/src/meusbd.c
@@ -882,7 +882,7 @@ __myevic__ uint32_t hidGetProfile( CMD_T *pCmd )
 			return 1;
 		}
 
-		p = (dfParams_t*)(DATAFLASH_PROFILES_SPACE+DATAFLASH_PARAMS_SIZE*(u32ProfileNum-1));
+		p = (dfParams_t*)(DATAFLASH_PROFILES_BASE+DATAFLASH_PARAMS_SIZE*(u32ProfileNum-1));
 	}
 
 	MemCpy( &hidData[0], (uint8_t *)p, DATAFLASH_PARAMS_SIZE );


### PR DESCRIPTION
DATAFLASH_PROFILES_SPACE is the length of the profile space in the data flash, while DATAFLASH_PROFILES_BASE is the beginning address.

Edit:
pushed another commit making hid_setprofile functional. The aim is to make profile editing with an external config tool possible.